### PR TITLE
feat: dockerize services and introduce docker-compose.yaml for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # Backend 
 
 ### Build & Run
-1. Run `make.sh` (see Makefile extras below)
-2. Go to `bin`
-3. Start login service : `./user-service user-service.yaml`
-4. Start request service: `./request-service request-service.yaml`
-5. Start game service: `./game-service` 
-~~5. [test] run `./gen-players.sh` to insert 10 dummy players~~ (still possible but not recommended avoid it, use the mongo)
+There are two ways to build and run the services:
+1. You can build and run them using `docker` and `docker compose` - this method will set everything up without the need to manually build the services and orcestrate them to run. To build and run the services this way, you need to know the following commands:
+    1. Run `docker compose up --build -d` in the project's root folder. The last `-d` flad tells docker to run them in detached mode, which means you can use the same console to test the services, too.
+    2. If running the services this way doesn't seem to work, then you can see what the logs for the different services are by running.
+     `docker logs -f <container_id or container_name>`.
+     You can get the names of the running containers using
+     `docker ps`   (if you'd like to see all containers, including the stopped ones, then run `docker ps -a` alternatively).
+1. Using the make script
+    1. Run `make.sh` (see Makefile extras below)
+    2. Go to `bin`
+    3. Start login service : `./user-service user-service.yaml`
+    4. Start request service: `./request-service request-service.yaml`
+    5. Start game service: `./game-service` 
+    ~~5. [test] run `./gen-players.sh` to insert 10 dummy players~~ (still possible but not recommended avoid it, use the mongo)
 
 
 ### Todo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,59 @@
-version: '3.8'
+networks:
+  backend:
+    driver: bridge # Use a bridge network for inter-service communication
 
 services:
   user-service:
     build:
       context: ./user-service
       dockerfile: Dockerfile
+    networks:
+      - backend
     ports:
       - "8080:8080" # REST API service port
     environment:
       - USER_SERVICE_ENV=production # Example environment variable
-    depends_on:
-      - game-service
-      - request-service
+    deploy:
+      resources:
+        limits:
+          memory: 100m # Limit memory usage for the service
+        reservations:
+          memory: 50m # Reserve memory for the service
 
   request-service:
     build:
       context: ./requests-service
       dockerfile: Dockerfile
+    networks:
+      - backend
     ports:
-      - "8081:8081" # gRPC service port
+      - "8081:8081" # REST API service port
       - "8082:8082" # WebSocket service port
     environment:
       - REQUEST_SERVICE_ENV=production # Example environment variable
     depends_on:
       - game-service
+      - user-service
+    deploy:
+      resources:
+        limits:
+          memory: 100m # Limit memory usage for the service
+        reservations:
+          memory: 50m # Reserve memory for the service
 
   game-service:
     build:
       context: ./game-service
       dockerfile: Dockerfile
+    networks:
+      - backend
     ports:
       - "50051:50051" # Map the container's port to the host
     environment:
       - GAME_SERVICE_ENV=production # Example environment variable
+    deploy:
+      resources:
+        limits:
+          memory: 100m # Limit memory usage for the service
+        reservations:
+          memory: 50m # Reserve memory for the service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  user-service:
+    build:
+      context: ./user-service
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080" # REST API service port
+    environment:
+      - USER_SERVICE_ENV=production # Example environment variable
+    depends_on:
+      - game-service
+      - request-service
+
+  request-service:
+    build:
+      context: ./requests-service
+      dockerfile: Dockerfile
+    ports:
+      - "8081:8081" # gRPC service port
+      - "8082:8082" # WebSocket service port
+    environment:
+      - REQUEST_SERVICE_ENV=production # Example environment variable
+    depends_on:
+      - game-service
+
+  game-service:
+    build:
+      context: ./game-service
+      dockerfile: Dockerfile
+    ports:
+      - "50051:50051" # Map the container's port to the host
+    environment:
+      - GAME_SERVICE_ENV=production # Example environment variable

--- a/game-service/Dockerfile
+++ b/game-service/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /app
+
+ADD bitvector/ bitvector
+ADD cleopatra/ cleopatra
+ADD slot-game/ slot-game
+ADD slots/ slots
+ADD util/ util
+
+COPY go.mod go.sum main.go ./
+
+RUN go mod download
+
+RUN CGO_ENABLED=0 go build -o game-service -ldflags="-X 'main.version=0.0.1'" -tags netgo -a -v main.go
+
+FROM alpine:latest
+
+WORKDIR /root/
+
+COPY --from=builder /app/game-service ./
+
+CMD ["./game-service"]

--- a/game-service/main.go
+++ b/game-service/main.go
@@ -17,6 +17,8 @@ import (
 )
 
 var (
+	version string = "local" // automatically populated by the build system
+
 	port = flag.Int("port", 50051, "The server port")
 	zl   = logger.ZapperLog{}
 	do   sync.Once
@@ -26,6 +28,8 @@ func log(level int, m string, zpf ...zap.Field) {
 	do.Do(func() {
 		zl.Init(1)
 	})
+
+	zpf = append(zpf, zap.String("version", version))
 	zl.Log(level, m, zpf...)
 }
 

--- a/requests-service/Dockerfile
+++ b/requests-service/Dockerfile
@@ -1,0 +1,24 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /app
+
+ADD models/ models
+ADD player-cache/ player-cache
+ADD proto-client/ proto-client
+ADD rest-server/ rest-server
+ADD serv-interface/ serv-interface
+ADD ws-server/ ws-server
+
+COPY go.mod go.sum requests-service.yaml main.go ./
+
+RUN go mod download
+
+RUN CGO_ENABLED=0 go build -o request-service -ldflags="-X 'main.version=0.0.1'" -tags netgo -a -v main.go
+
+FROM alpine:latest
+
+WORKDIR /root/
+
+COPY --from=builder /app/request-service /app/requests-service.yaml ./
+
+CMD ["./request-service", "requests-service.yaml"]

--- a/requests-service/main.go
+++ b/requests-service/main.go
@@ -30,7 +30,6 @@ func log(level int, m string, zpf ...zap.Field) {
 }
 
 func main() {
-
 	if len(os.Args) != 2 {
 		log(logger.CRITICAL, "Error usage: provide config file")
 		//	os.Exit(-1)
@@ -45,7 +44,12 @@ func main() {
 		os.Exit(-2)
 	}
 
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
 	go func() {
+		defer wg.Done()
+
 		var srvIface servinterface.ServiceInterface
 		log(logger.INFO, "--- rest service up ---")
 		srvIface = &server.Server{}
@@ -56,12 +60,17 @@ func main() {
 	}()
 
 	go func() {
-		var srvIface servinterface.ServiceInterface
+		defer wg.Done()
+
 		log(logger.INFO, "--- websocket service up ---")
-		srvIface = &websocket.WSServer{}
-		if err := srvIface.DoRun(&srvconf); err != nil {
+
+		srv := websocket.NewServer("game-service:50051")
+
+		if err := srv.DoRun(&srvconf); err != nil {
 			log(logger.CRITICAL, "Failed run websocket service", zap.Any("what", err))
 			os.Exit(-1)
 		}
 	}()
+
+	wg.Wait()
 }

--- a/requests-service/main.go
+++ b/requests-service/main.go
@@ -14,6 +14,8 @@ import (
 )
 
 var (
+	version string = "local" // automatically populated by the build system
+
 	zl = logger.ZapperLog{}
 	do sync.Once
 )
@@ -22,6 +24,8 @@ func log(level int, m string, zpf ...zap.Field) {
 	do.Do(func() {
 		zl.Init(logger.DEV)
 	})
+
+	zpf = append(zpf, zap.String("version", version))
 	zl.Log(level, m, zpf...)
 }
 
@@ -59,8 +63,5 @@ func main() {
 			log(logger.CRITICAL, "Failed run websocket service", zap.Any("what", err))
 			os.Exit(-1)
 		}
-
 	}()
-
-	select {}
 }

--- a/requests-service/proto-client/win-request.go
+++ b/requests-service/proto-client/win-request.go
@@ -20,11 +20,8 @@ const (
 )
 
 var (
-	//todo : change make it configurable
-	addr = flag.String("addr", "localhost:50051", "the address to connect to")
-	name = flag.String("Name", defaultName, "Name to greet")
-	zl   = logger.ZapperLog{}
-	do   sync.Once
+	zl = logger.ZapperLog{}
+	do sync.Once
 )
 
 func log(level int, m string, zpf ...zap.Field) {
@@ -38,14 +35,24 @@ type WinRequest struct {
 	PlayerRequest     *pb.PlayerRequest
 	PlayerResponse    *pb.PlayerResponse
 	CleopatraResponse *pb.CleopatraWins
+	Addr              string
+}
+
+func New(addr string) WinRequest {
+	return WinRequest{
+		PlayerRequest:     &pb.PlayerRequest{},
+		PlayerResponse:    &pb.PlayerResponse{},
+		CleopatraResponse: &pb.CleopatraWins{},
+		Addr:              addr,
+	}
 }
 
 func (wr *WinRequest) SendWin4Cleo(id, money uint64) error {
 	flag.Parse()
 	// Set up a connection to the server.
-	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(wr.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return errors.New("No connection to game service ")
+		return errors.New("no connection to game service ")
 	}
 	defer conn.Close()
 	c := pb.NewServiceGameWonClient(conn)
@@ -56,7 +63,7 @@ func (wr *WinRequest) SendWin4Cleo(id, money uint64) error {
 	pr := &pb.PlayerRequest{Id: &id, Bet: &money}
 	wr.CleopatraResponse, err = c.GetWinForCleopatra(ctx, pr) //IVZ
 	if err != nil {
-		return errors.New(fmt.Sprint("could not greet: %v", err))
+		return fmt.Errorf("could not greet: %v", err)
 	}
 
 	return nil
@@ -65,9 +72,9 @@ func (wr *WinRequest) SendWin4Cleo(id, money uint64) error {
 func (wr *WinRequest) SendWin(id uint64) error {
 	flag.Parse()
 	// Set up a connection to the server.
-	conn, err := grpc.NewClient(*addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(wr.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return errors.New("No connection to game service ")
+		return errors.New("no connection to game service ")
 	}
 	defer conn.Close()
 	c := pb.NewServiceGameWonClient(conn)
@@ -78,7 +85,7 @@ func (wr *WinRequest) SendWin(id uint64) error {
 	pr := &pb.PlayerRequest{Id: &id}
 	wr.PlayerResponse, err = c.GetWinForPlayer(ctx, pr) //IVZ
 	if err != nil {
-		return errors.New(fmt.Sprint("could not greet: %v", err))
+		return fmt.Errorf("could not greet: %v", err)
 	}
 	log(logger.DEBUG, "cryptowin proto", zap.Uint64("id", wr.PlayerResponse.GetId()),
 		zap.Uint64("won", wr.PlayerResponse.GetMoneyWon()),

--- a/requests-service/requests-service.yaml
+++ b/requests-service/requests-service.yaml
@@ -1,8 +1,8 @@
 
 database_url: postgres://postgres:@localhost:5432/database_dev
 database_type: mongo
-rest_service_host: localhost
+rest_service_host: 0.0.0.0
 rest_service_port: 8082
-ws_service_host: localhost
+ws_service_host: 0.0.0.0
 ws_service_port: 8081
 game_serv_port: 50051

--- a/requests-service/rest-server/server.go
+++ b/requests-service/rest-server/server.go
@@ -29,12 +29,10 @@ type Server struct {
 }
 
 func (srv *Server) DoRun(conf *config.RequestService) error {
-
 	if conf.DatabaseType == "mongo" {
 		srv.dbiface = &db.NoSqlConnection{}
 		srv.dbiface.Init("Cluster0", "cryptowincryptowin:EfK0weUUe7t99Djx")
 		srv.router = gin.Default()
-
 	} else {
 		srv.dbiface = &db.DBSqlConnection{}
 		srv.dbiface.Init("sqlite3", "players.db")
@@ -42,6 +40,7 @@ func (srv *Server) DoRun(conf *config.RequestService) error {
 		defer srv.dbiface.Deinit()
 		srv.dbiface.(*db.DBSqlConnection).CreatePlayersTable()
 	}
+
 	srv.router.Use(cors.New(cors.Config{
 		AllowOrigins:     []string{"*"}, // or fe 3000
 		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
@@ -50,6 +49,7 @@ func (srv *Server) DoRun(conf *config.RequestService) error {
 		AllowCredentials: false,
 		MaxAge:           12 * time.Hour,
 	}))
+
 	//this fails to resolve cors so will leave it in case the above fix does not work with FE
 	//	srv.router.Use(cors.New(cors.Config{
 	//		AllowOrigins: []string{"http://localhost:3000"}, // Next.js frontend

--- a/requests-service/ws-server/ws-server.go
+++ b/requests-service/ws-server/ws-server.go
@@ -58,12 +58,10 @@ var upgrader = websocket.Upgrader{
 }
 
 func (srv *WSServer) DoRun(conf *config.RequestService) error {
-
 	if conf.DatabaseType == "mongo" {
 		srv.dbiface = &db.NoSqlConnection{}
 		srv.dbiface.Init("Cluster0", "cryptowincryptowin:EfK0weUUe7t99Djx")
 		srv.router = gin.Default()
-
 	} else {
 		srv.dbiface = &db.DBSqlConnection{}
 		srv.dbiface.Init("sqlite3", "players.db")

--- a/requests-service/ws-server/ws-server.go
+++ b/requests-service/ws-server/ws-server.go
@@ -16,7 +16,6 @@ import (
 )
 
 type WSServer struct {
-	Host    string
 	Port    uint16
 	router  *gin.Engine
 	dbiface db.DbIface
@@ -55,6 +54,13 @@ var upgrader = websocket.Upgrader{
 		// Allow all connections
 		return true
 	},
+}
+
+func NewServer(addr string) WSServer {
+	return WSServer{
+		Port:   8080,
+		winReq: server.New(addr),
+	}
 }
 
 func (srv *WSServer) DoRun(conf *config.RequestService) error {

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.24 AS builder
+
+WORKDIR /app
+
+ADD handlers/ handlers
+COPY go.mod go.sum user-service.yaml main.go ./
+
+RUN go mod download
+
+RUN CGO_ENABLED=0 go build -o user-service -ldflags="-X 'main.version=0.0.1'" -tags netgo -a -v main.go
+
+FROM alpine:latest
+
+WORKDIR /root/
+
+COPY --from=builder /app/user-service /app/user-service.yaml ./
+
+CMD ["./user-service", "user-service.yaml"]

--- a/user-service/go.mod
+++ b/user-service/go.mod
@@ -5,6 +5,7 @@ go 1.24.1
 require (
 	github.com/ExtraWhy/internal-libs v1.1.0
 	github.com/gin-gonic/gin v1.10.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/oauth2 v0.28.0
 )
 
@@ -41,6 +42,7 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.mongodb.org/mongo-driver v1.17.3 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.2.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.12.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect

--- a/user-service/go.sum
+++ b/user-service/go.sum
@@ -100,6 +100,12 @@ go.mongodb.org/mongo-driver v1.17.3 h1:TQyXhnsWfWtgAhMtOgtYHMTkZIfBTpMTsMnd9ZBeH
 go.mongodb.org/mongo-driver v1.17.3/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.mongodb.org/mongo-driver/v2 v2.2.0 h1:WwhNgGrijwU56ps9RtIsgKfGLEZeypxqbEYfThrBScM=
 go.mongodb.org/mongo-driver/v2 v2.2.0/go.mod h1:qQkDMhCGWl3FN509DfdPd4GRBLU/41zqF/k8eTRceps=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/arch v0.12.0 h1:UsYJhbzPYGsT0HbEdmYcqtCv8UNGvnaL561NnIUvaKg=
 golang.org/x/arch v0.12.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -30,7 +30,7 @@ func log(level int, m string, zpf ...zap.Field) {
 }
 
 func main() {
-	log(logger.INFO, "Starting user-service", zap.String("version", version))
+	log(logger.INFO, "Starting user-service")
 
 	yaml_config_path := "user-service.yaml"
 

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -3,13 +3,34 @@ package main
 import (
 	"fmt"
 	"os"
+	"sync"
 	"user-service/handlers"
 
 	"github.com/ExtraWhy/internal-libs/config"
 	"github.com/ExtraWhy/internal-libs/db"
+
+	"github.com/ExtraWhy/internal-libs/logger"
+	"go.uber.org/zap"
 )
 
+var (
+	version string = "local" // automatically populated by the build system
+
+	zl = logger.ZapperLog{}
+	do sync.Once
+)
+
+func log(level int, m string, zpf ...zap.Field) {
+	do.Do(func() {
+		zl.Init(1)
+	})
+
+	zpf = append(zpf, zap.String("version", version))
+	zl.Log(level, m, zpf...)
+}
+
 func main() {
+	log(logger.INFO, "Starting user-service", zap.String("version", version))
 
 	yaml_config_path := "user-service.yaml"
 


### PR DESCRIPTION
- Readme.MD was updated to include some instruction about how to run/use `docker` and `docker compose`
- The existing code was refactored a bit as a preparation to start injecting the config parameters as env variables or command-line arguments in order to make the local development easier.