### PR TITLE
feat: allow for multi-container setup for services in local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,56 @@
 # Backend 
 
-### Build & Run
-There are two ways to build and run the services:
-1. You can build and run them using `docker` and `docker compose` - this method will set everything up without the need to manually build the services and orcestrate them to run. To build and run the services this way, you need to know the following commands:
-    1. Run `docker compose up --build -d` in the project's root folder. The last `-d` flad tells docker to run them in detached mode, which means you can use the same console to test the services, too.
-    2. If running the services this way doesn't seem to work, then you can see what the logs for the different services are by running.
-     `docker logs -f <container_id or container_name>`.
-     You can get the names of the running containers using
-     `docker ps`   (if you'd like to see all containers, including the stopped ones, then run `docker ps -a` alternatively).
-    3. If you encounter problems that a specific image is taken or being used, just run `docker system prune -a --volumes` to clean docker and follow step `1.`
-1. Using the make script
-    1. Run `make.sh` (see Makefile extras below)
-    2. Go to `bin`
-    3. Start login service : `./user-service user-service.yaml`
-    4. Start request service: `./request-service request-service.yaml`
-    ~~5. Start game service: `./game-service`~~ 
-    ~~5. [test] run `./gen-players.sh` to insert 10 dummy players~~ (still possible but not recommended avoid it, use the mongo)
+## Build & Run
+There are two ways to build and run the services - using `docker compose` and using the make script
+
+### Build & Run using docker compose
+You can build and run them using `docker` and `docker compose` - this method will set everything up without the need to manually build the services and orcestrate them to run. To build and run the services this way, you need to know the following commands:
+1. Run `docker compose up --build -d` in the project's root folder. The last `-d` flad tells docker to run them in detached mode, which means you can use the same console to test the services, too.
+2. If running the services this way doesn't seem to work, then you can see what the logs for the different services are by running.
+    `docker logs -f <container_id or container_name>`.
+    You can get the names of the running containers using
+    `docker ps`   (if you'd like to see all containers, including the stopped ones, then run `docker ps -a` alternatively).
+3. If you encounter problems that a specific image is taken or being used, just run `docker system prune -a --volumes` to clean docker and follow step `1.`
+
+Docker compose setup supports also the scaling up and down of the services it runs. For example, the default setup runs 1 instance of each service by default. However, if you'd like scale some service up, then you can do the following:
+```
+docker compose up --build --scale request-service=3 -d
+```
+In the above command, we tell docker compose to run 3 instances of request-service.
+
+Another useful command with docker is
+```
+docker stats
+```
+This will show you realtime statistics for the running container and, if run in the above scenario, with the Browser Tests running as well, it will show you that the CPU of all the request-service containers go up indicating the load balancing is working properly and the requests are distributed between all three containers.
+
+### Build & Run using the make script
+1. Run `make.sh` (see Makefile extras below)
+1. Go to `bin`
+1. Start login service : `./user-service user-service.yaml`
+1. Start request service: `./request-service request-service.yaml`
+~~5. Start game service: `./game-service`~~ 
+~~5. [test] run `./gen-players.sh` to insert 10 dummy players~~ (still possible but not recommended avoid it, use the mongo)
 
 
-### Todo:
+## Todo:
 1. ~~Learn uber's zap logger and use it accordingly in the project~~
 2. ~~Replace all printlines with `logger.ZapperLog` and use it for everything~~
 3. Recovery implementation
 4. History implementation
 5. Free games
 
-### Protobuf server-client [deprecated soon]
+## Protobuf server-client [deprecated soon]
 ~~1. Those are just a template usages of grpc~~
 ~~2. Use as reference not for final product we will need much more~~
 ~~3. Fixed also make to deal with those 2~~
 
-### Makefile extras
+## Makefile extras
 1. Run `./make.sh` with no args to build and update go modules of all projects
 2. Run `./make.sh <branchname>` to build and update go modules from `internal-libs` on your branchname from `internal-libs` branch
 3. Run `./make.sh -n` to only build projects with no update of go modules of `internal-libs` (local build faster)
 
-### Test for RTP
+## Test for RTP
 1. run `./make.sh`
 2. go to `bin` folder
 3. modify `requests-service.yaml` to use `sqlite3` instead of `mongo` if you are offline, otherwise leave unchanged.
@@ -46,12 +61,12 @@ There are two ways to build and run the services:
 8. You may watch the histogram in the canvas and track the rtp percentage in the console log.
 
 
-### fe-tests
+## fe-tests
 1. `multi-bet.html` creates 10 websocket clients that betting infinitely and also asks in 5 seconds for get players/winners
 2. `pay-histogram.html` - histogram of payments , bets infinitely with 100 on 1 id and plots the paytable
 
 
-### RNG
+## RNG
 1. We have to give a good seed per user session (not per game )
 2. Good approach is to seed mt19973 with dev/urandom or golangs embeded crypto/rand
 3. In real life 2 players will have different seeds so the deterministic output cannot be predicted avoiding bruteforce

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,0 +1,48 @@
+worker_processes 1;
+
+events { 
+    worker_connections 1024;
+}
+
+http {
+    upstream request_service_websocket{
+        least_conn;
+        server request-service:8081;
+    }
+
+    upstream request_service_rest {
+        least_conn;
+        server request-service:8082;
+    }
+
+    upstream user_service_rest {
+        least_conn;
+        server user-service:8080;
+    }
+
+    server {
+        listen 8080;
+        location / {
+            proxy_pass http://user_service_rest;
+        }
+    }
+
+    server {
+        listen 8081;
+        location / {
+            proxy_pass http://request_service_websocket;
+            
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+
+    server {
+        listen 8082;
+        location / {
+            proxy_pass http://request_service_rest;
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,16 @@ services:
     networks:
       - backend
     ports:
-      - "8080:8080" # REST API service port
+      - "8080" # REST API service port
     environment:
       - USER_SERVICE_ENV=production # Example environment variable
     deploy:
       resources:
         limits:
-          memory: 100m # Limit memory usage for the service
+          cpus: '0.1'
+          memory: 10m
         reservations:
-          memory: 50m # Reserve memory for the service
+          memory: 6m
 
   request-service:
     build:
@@ -27,8 +28,8 @@ services:
     networks:
       - backend
     ports:
-      - "8081:8081" # REST API service port
-      - "8082:8082" # WebSocket service port
+      - "8081" # REST API service port
+      - "8082" # WebSocket service port
     environment:
       - REQUEST_SERVICE_ENV=production # Example environment variable
     depends_on:
@@ -36,7 +37,30 @@ services:
     deploy:
       resources:
         limits:
-          memory: 100m # Limit memory usage for the service
+          cpus: '0.4'
+          memory: 15m
         reservations:
-          memory: 50m # Reserve memory for the service
+          memory: 10m
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx
+    networks:
+      - backend
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+      - "8082:8082"
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro # Mount custom Nginx configuration
+    depends_on:
+      - user-service
+      - request-service
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 6m
+        reservations:
+          memory: 6m
 

--- a/requests-service/Dockerfile
+++ b/requests-service/Dockerfile
@@ -11,6 +11,7 @@ ADD game/util game/util
 ADD rest-server/ rest-server
 ADD serv-interface/ serv-interface
 ADD ws-server/ ws-server
+ADD recovery/ recovery
 
 COPY go.mod go.sum requests-service.yaml main.go ./
 RUN go mod download


### PR DESCRIPTION
 Allow for multi-container setup for services in local setup through Docker compose

This one utilizes docker-compose and allows for spinning up multiple services of a certain type.
Please refer to the updated Readme.MD file for more info and example commands.